### PR TITLE
Fix ginkgo moved to gomod

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,7 +48,7 @@ RUN \
     # --> GolangCI-lint
     && curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sed 's/tar -/tar --no-same-owner -/g' | sh -s -- -b $(go env GOPATH)/bin \
     # --> Install Ginkgo
-    && go get github.com/onsi/ginkgo/ginkgo@v1.11.0 \
+    && go get github.com/onsi/ginkgo/ginkgo@v1.12.0  \
     # --> Install junit converter
     && go get github.com/jstemmer/go-junit-report@v0.9.1 \
     && rm -rf /go/src/ && rm -rf /go/pkg


### PR DESCRIPTION
The old version of ginkgo didn't use go modules and a downstream dependency change broke it (I think).  

This PR fixes that in Ginkgo by moving to https://github.com/onsi/ginkgo/releases/tag/v1.12.0

We now moved to 1.12 of ginkgo to get that into our build.